### PR TITLE
Fix ActionBar overlapping long scripts in sidepanel

### DIFF
--- a/entrypoints/sidepanel/components/ActionBar.tsx
+++ b/entrypoints/sidepanel/components/ActionBar.tsx
@@ -14,10 +14,7 @@ const styles: Record<string, Record<string, string | number>> = {
     borderTop: '1px solid #e5e5e5',
     background: 'white',
     padding: '6px 0 8px',
-    position: 'fixed' as const,
-    bottom: 0,
-    left: 0,
-    right: 0,
+    flexShrink: 0,
     zIndex: 100,
   },
   button: {


### PR DESCRIPTION
Problem:
When scripts become long, the ActionBar was overlaying the bottom part of the list because it was using position: fixed.

Result:
Users could not scroll to the end of the script.

Solution:
Removed position: fixed and replaced it with flexShrink: 0 so the ActionBar stays at the bottom of the layout without covering the content.

File changed:
entrypoints/sidepanel/components/ActionBar.tsx